### PR TITLE
fix(hk): scope gitleaks to pre-commit to stop key.txt false positives

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -11,7 +11,6 @@ local linters = new Mapping<String, Step> {
   ["newlines"] = Builtins.newlines
   ["mixed_line_ending"] = Builtins.mixed_line_ending
   ["pkl_format"] = Builtins.pkl_format
-  ["gitleaks"] = Builtins.gitleaks
   ["typos"] = Builtins.typos
   ["mise"] = Builtins.mise
   ["oxfmt"] = Builtins.oxfmt
@@ -24,7 +23,14 @@ hooks {
   ["pre-commit"] {
     fix = true
     stash = "git"
-    steps = linters
+    // gitleaks only runs here: it scans staged files, so the gitignored
+    // local age key (key.txt) is never scanned in a normal commit and never
+    // false-positives. A force-added (`git add -f key.txt`) secret is still
+    // staged and gets blocked. Keeping it out of check/fix avoids the
+    // whole-tree (`--all`) false positive without needing a .gitleaksignore.
+    steps = (linters) {
+      ["gitleaks"] = Builtins.gitleaks
+    }
   }
   ["fix"] {
     fix = true


### PR DESCRIPTION
## What

Move the `gitleaks` step out of the shared `linters` mapping and run it **only in the `pre-commit` hook**. Also removes the local-only `.gitleaksignore` allowlist hack.

## Why

`gitleaks` (in `dir` mode) was wired into every hook. On whole-tree runs (`hk check/fix --all`), hk enumerates the **gitignored local age key `key.txt`** and passes it to gitleaks explicitly, producing a false positive. This previously required an untracked `.gitleaksignore` allowlisting key.txt's fingerprints.

That allowlist is itself a risk: if `key.txt` were ever force-added (`git add -f key.txt`), pre-commit's gitleaks would scan it but the allowlist would **silently suppress** the finding → real secret committable.

## Behavior after this change

| Scenario | Result |
|---|---|
| Normal commit | gitleaks scans staged files; key.txt never staged → no false positive |
| `git add -f key.txt` | gitleaks detects `age-secret-key` → **commit blocked** ✅ |
| `hk check/fix --all` | gitleaks does not run → no false positive |

## Trade-off

Secret scanning no longer runs in `hk check/fix` (incl. `--all`); the enforcement point is the commit gate (pre-commit), which is preserved.

## Verification

- Normal staged commit → gitleaks `no leaks found`, passes
- `git add -f key.txt` → gitleaks blocks on `age-secret-key`
- `hk check --all` → gitleaks absent, no key.txt finding
- `hk validate` → config valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)